### PR TITLE
Add ability to pass params to query with :foo syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sqlcell_dev*.ipynb
 **/.ipynb_checkpoints
 .DS_Store
 *.egg-info
+dist/sqlcell-*

--- a/Pipfile
+++ b/Pipfile
@@ -14,8 +14,8 @@ ipywidgets = "*"
 pymssql = "*"
 cython = "*"
 jupyterlab-git = "*"
-psycopg2 = "*"
 six = ">=1.9.0"
+psycopg2 = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -102,11 +102,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:0aeb7ec277ac42cc2b59ae3d08b10909b2ec161dc6908096210527162b53675d",
-                "sha256:0fc0bf97920d454102168ec2008620066878848fcfca06c22b669696212e292f"
+                "sha256:346189536b88859937b5f4848a6fd85d1ad0729f01724a411de5cae9b618819c",
+                "sha256:f0e962052718068ad3b1d8bcc703794660858f58803c3798628817f492a8769c"
             ],
             "index": "pypi",
-            "version": "==5.1.0"
+            "version": "==5.1.1"
         },
         "ipython": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sqlcell",
-    version="0.2.0.9",
+    version="0.2.0.10",
     description="run sql in jupyter notebooks or jupyter lab",
     license="MIT",
     author="Tim Dobbins",


### PR DESCRIPTION
This will allow user to pass params to query like so:

```
foo = 'bar'
baz = (1,2,3,4)

%%sql
select * from table where foo = :foo and baz in :baz
```