### PR TITLE
Add engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ sqlcell_dev*.ipynb
 **/.ipynb_checkpoints
 .DS_Store
 *.egg-info
+dist/*
 dist/sqlcell-*


### PR DESCRIPTION
add `--engines` argument to easily persist aliases for engine connection strings 